### PR TITLE
EStringParser: set the end_string parameter optional

### DIFF
--- a/src/grammar/pattern.rustpeg
+++ b/src/grammar/pattern.rustpeg
@@ -1,6 +1,6 @@
 use matcher::trie::node::{CompiledPattern};
 use matcher::trie::node::{Node, TokenType};
-use parsers::{SetParser, IntParser, Parser, OptionalParameter, HasOptionalParameter, EStringParser};
+use parsers::{SetParser, IntParser, Parser, OptionalParameter, HasOptionalParameter, GreedyParser};
 use grammar;
 use utils;
 
@@ -57,7 +57,7 @@ parser_INT_optional_params -> Vec<OptionalParameter<'input>>
 parser_GREEDY -> Vec<TokenType>
   = PARSER_BEGIN GREEDY name:parser_name PARSER_END end_string:literal? {
     let mut tokens = Vec::new();
-    let mut parser = EStringParser::new(name.to_string());
+    let mut parser = GreedyParser::new(name.to_string());
 
     if let Some(end_string) = end_string {
       parser.set_end_string(end_string.to_string());

--- a/src/grammar/pattern.rustpeg
+++ b/src/grammar/pattern.rustpeg
@@ -55,10 +55,21 @@ parser_INT_optional_params -> Vec<OptionalParameter<'input>>
   = PARSER_PARAMS_BEGIN params:parser_BASE_optional_param ** comma PARSER_PARAMS_END { params }
 
 parser_GREEDY -> Vec<TokenType>
-  = PARSER_BEGIN GREEDY name:parser_name PARSER_END end_string:literal {
-    let parser = EStringParser::from_str(name, end_string);
-    vec![TokenType::Parser(Box::new(parser)),
-         TokenType::Literal(end_string.to_string())]
+  = PARSER_BEGIN GREEDY name:parser_name PARSER_END end_string:literal? {
+    let mut tokens = Vec::new();
+    let mut parser = EStringParser::new(name.to_string());
+
+    if let Some(end_string) = end_string {
+      parser.set_end_string(end_string.to_string());
+    }
+
+    tokens.push(TokenType::Parser(Box::new(parser)));
+
+    if let Some(end_string) = end_string {
+      tokens.push(TokenType::Literal(end_string.to_string()));
+    }
+
+    tokens
   }
 
 parser_BASE_optional_param -> OptionalParameter<'input>

--- a/src/grammar/pattern_parser.rs
+++ b/src/grammar/pattern_parser.rs
@@ -3,7 +3,7 @@
 use matcher::trie::node::{CompiledPattern};
 use matcher::trie::node::{Node, TokenType};
 use parsers::{SetParser, IntParser, Parser, OptionalParameter,
-              HasOptionalParameter, EStringParser};
+              HasOptionalParameter, GreedyParser};
 use grammar;
 use utils;
 use std::str::FromStr;
@@ -600,7 +600,7 @@ fn parse_parser_GREEDY<'input>(input: &'input str, state: &mut ParseState,
                                                                                     let mut tokens =
                                                                                         Vec::new();
                                                                                     let mut parser =
-                                                                                        EStringParser::new(name.to_string());
+                                                                                        GreedyParser::new(name.to_string());
                                                                                     if let Some(end_string)
                                                                                            =
                                                                                            end_string

--- a/src/grammar/pattern_parser.rs
+++ b/src/grammar/pattern_parser.rs
@@ -572,9 +572,22 @@ fn parse_parser_GREEDY<'input>(input: &'input str, state: &mut ParseState,
                                                     Matched(pos, _) => {
                                                         {
                                                             let seq_res =
-                                                                parse_literal(input,
-                                                                              state,
-                                                                              pos);
+                                                                match parse_literal(input,
+                                                                                    state,
+                                                                                    pos)
+                                                                    {
+                                                                    Matched(newpos,
+                                                                            value)
+                                                                    => {
+                                                                        Matched(newpos,
+                                                                                Some(value))
+                                                                    }
+                                                                    Failed =>
+                                                                    {
+                                                                        Matched(pos,
+                                                                                None)
+                                                                    }
+                                                                };
                                                             match seq_res {
                                                                 Matched(pos,
                                                                         end_string)
@@ -584,29 +597,24 @@ fn parse_parser_GREEDY<'input>(input: &'input str, state: &mut ParseState,
                                                                             &input[start_pos..pos];
                                                                         Matched(pos,
                                                                                 {
-                                                                                    let parser =
-                                                                                        EStringParser::from_str(name,
-                                                                                                                end_string);
-                                                                                    vec!(TokenType::
-                                                                                         Parser
-                                                                                         (
-                                                                                         Box::
-                                                                                         new
-                                                                                         (
-                                                                                         parser
-                                                                                         )
-                                                                                         )
-                                                                                         ,
-                                                                                         TokenType::
-                                                                                         Literal
-                                                                                         (
-                                                                                         end_string
-                                                                                         .
-                                                                                         to_string
-                                                                                         (
-
-                                                                                         )
-                                                                                         ))
+                                                                                    let mut tokens =
+                                                                                        Vec::new();
+                                                                                    let mut parser =
+                                                                                        EStringParser::new(name.to_string());
+                                                                                    if let Some(end_string)
+                                                                                           =
+                                                                                           end_string
+                                                                                           {
+                                                                                        parser.set_end_string(end_string.to_string());
+                                                                                    }
+                                                                                    tokens.push(TokenType::Parser(Box::new(parser)));
+                                                                                    if let Some(end_string)
+                                                                                           =
+                                                                                           end_string
+                                                                                           {
+                                                                                        tokens.push(TokenType::Literal(end_string.to_string()));
+                                                                                    }
+                                                                                    tokens
                                                                                 })
                                                                     }
                                                                 }

--- a/src/grammar/test.rs
+++ b/src/grammar/test.rs
@@ -145,3 +145,15 @@ fn test_given_greedy_parser_when_we_parse_it_then_we_get_the_right_result() {
     assert_literal_equals(vec.get(4), " baz");
     assert_parser_equals(vec.get(3), &expected_parser);
 }
+
+#[test]
+fn test_given_greedy_parser_when_there_is_no_literal_after_it_then_we_take_all_the_remaining_intput_as_matching() {
+    let pattern_as_string = "bar %{GREEDY:greedy}";
+    let vec: Vec<TokenType<>> = pattern_parser::pattern(pattern_as_string).ok().unwrap();
+
+    if let &TokenType::Parser(ref parser) = vec.get(1).unwrap() {
+        assert_eq!(parser.parse("the quick brown fox"), Some(("greedy", "the quick brown fox")));
+    } else {
+        unreachable!();
+    }
+}

--- a/src/grammar/test.rs
+++ b/src/grammar/test.rs
@@ -1,6 +1,6 @@
 use super::pattern_parser;
 use matcher::trie::node::TokenType;
-use parsers::{SetParser, Parser, ObjectSafeHash, IntParser, EStringParser};
+use parsers::{SetParser, Parser, ObjectSafeHash, IntParser, GreedyParser};
 
 fn assert_parser_name_equals(item: Option<&TokenType>, expected_name: &str) {
     if let Some(&TokenType::Parser(ref parser)) = item {
@@ -133,7 +133,7 @@ fn test_given_int_parser_with_optional_parameters_when_we_parse_it_then_we_get_t
 
 #[test]
 fn test_given_greedy_parser_when_we_parse_it_then_we_get_the_right_result() {
-    let expected_parser = EStringParser::from_str("greedy", " baz");
+    let expected_parser = GreedyParser::from_str("greedy", " baz");
     let pattern_as_string = "foo %{INT:int_0} bar %{GREEDY:greedy} baz";
     let vec: Vec<TokenType<>> = pattern_parser::pattern(pattern_as_string).ok().unwrap();
 

--- a/src/parsers/estring.rs
+++ b/src/parsers/estring.rs
@@ -4,17 +4,23 @@ use super::{ParserBase, Parser, ObjectSafeHash};
 #[derive(Debug, Hash)]
 pub struct EStringParser {
     base: ParserBase,
-    end_string: String
+    end_string: Option<String>
 }
 
 impl EStringParser {
-    pub fn new(name: String, end_string: String) -> EStringParser {
+    pub fn new(name: String) -> EStringParser {
         EStringParser{ base: ParserBase::new(name),
-                       end_string: end_string }
+                       end_string: None }
     }
 
     pub fn from_str(name: &str, end_string: &str) -> EStringParser {
-        EStringParser::new(name.to_string(), end_string.to_string())
+        let mut parser = EStringParser::new(name.to_string());
+        parser.set_end_string(end_string.to_string());
+        parser
+    }
+
+    pub fn set_end_string(&mut self, end_string: String) {
+        self.end_string = Some(end_string);
     }
 }
 
@@ -29,7 +35,11 @@ impl ObjectSafeHash for EStringParser {
 
 impl Parser for EStringParser {
     fn parse<'a, 'b>(&'a self, value: &'b str) -> Option<(&'a str, &'b str)> {
-        if let Some(pos) = value.find(&self.end_string) {
+        if self.end_string.is_none() {
+            return Some((self.name(), &value[..]))
+        }
+
+        if let Some(pos) = value.find(&self.end_string.as_ref().unwrap()[..]) {
             Some((self.name(), &value[..pos]))
         } else {
             None

--- a/src/parsers/greedy.rs
+++ b/src/parsers/greedy.rs
@@ -2,19 +2,19 @@ use std::hash::{SipHasher, Hash, Hasher};
 use super::{ParserBase, Parser, ObjectSafeHash};
 
 #[derive(Debug, Hash)]
-pub struct EStringParser {
+pub struct GreedyParser {
     base: ParserBase,
     end_string: Option<String>
 }
 
-impl EStringParser {
-    pub fn new(name: String) -> EStringParser {
-        EStringParser{ base: ParserBase::new(name),
+impl GreedyParser {
+    pub fn new(name: String) -> GreedyParser {
+        GreedyParser{ base: ParserBase::new(name),
                        end_string: None }
     }
 
-    pub fn from_str(name: &str, end_string: &str) -> EStringParser {
-        let mut parser = EStringParser::new(name.to_string());
+    pub fn from_str(name: &str, end_string: &str) -> GreedyParser {
+        let mut parser = GreedyParser::new(name.to_string());
         parser.set_end_string(end_string.to_string());
         parser
     }
@@ -24,16 +24,16 @@ impl EStringParser {
     }
 }
 
-impl ObjectSafeHash for EStringParser {
+impl ObjectSafeHash for GreedyParser {
     fn hash_os(&self) -> u64 {
         let mut hasher = SipHasher::new();
-        "parser:estring".hash(&mut hasher);
+        "parser:greedy".hash(&mut hasher);
         self.hash(&mut hasher);
         hasher.finish()
     }
 }
 
-impl Parser for EStringParser {
+impl Parser for GreedyParser {
     fn parse<'a, 'b>(&'a self, value: &'b str) -> Option<(&'a str, &'b str)> {
         if self.end_string.is_none() {
             return Some((self.name(), &value[..]))
@@ -53,17 +53,17 @@ impl Parser for EStringParser {
 
 #[cfg(test)]
 mod test {
-    use parsers::{EStringParser, Parser};
+    use parsers::{GreedyParser, Parser};
 
     #[test]
-    fn test_given_estring_parser_when_the_end_string_is_not_found_in_the_value_then_the_parser_doesnt_match() {
-        let parser = EStringParser::from_str("name", "foo");
+    fn test_given_greedy_parser_when_the_end_string_is_not_found_in_the_value_then_the_parser_doesnt_match() {
+        let parser = GreedyParser::from_str("name", "foo");
         assert_eq!(parser.parse("qux baz bar"), None);
     }
 
     #[test]
-    fn test_given_estring_parser_when_the_end_string_is_found_in_the_value_then_the_parser_matches() {
-        let parser = EStringParser::from_str("name", "foo");
+    fn test_given_greedy_parser_when_the_end_string_is_found_in_the_value_then_the_parser_matches() {
+        let parser = GreedyParser::from_str("name", "foo");
         assert_eq!(parser.parse("qux foo bar"), Some(("name", "qux ")));
     }
 }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -2,14 +2,14 @@ mod set;
 mod base;
 mod int;
 mod length_checked;
-mod estring;
+mod greedy;
 
 use std::fmt::Debug;
 pub use self::set::SetParser;
 pub use self::base::ParserBase;
 pub use self::int::IntParser;
 pub use self::length_checked::LengthCheckedParserBase;
-pub use self::estring::EStringParser;
+pub use self::greedy::GreedyParser;
 
 pub trait ObjectSafeHash {
     fn hash_os(&self) -> u64;


### PR DESCRIPTION
It makes sense to use GREEDY parsers at the end of patterns. This commit
removes the need of the following literal.

A commit also renames EStringParser to GreedyParser.

Signed-off-by: Tibor Benke <ihrwein@gmail.com>