### PR TITLE
F/log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ path = "src/bin/adbtool.rs"
 
 [dependencies]
 clap = "*"
+log = "*"

--- a/src/bin/adbtool.rs
+++ b/src/bin/adbtool.rs
@@ -1,10 +1,14 @@
 extern crate actiondb;
 extern crate clap;
+#[macro_use]
+extern crate log;
 
 mod parse;
 
 use clap::{Arg, App, SubCommand, ArgMatches};
 use actiondb::Matcher;
+use log::{LogLevelFilter};
+use actiondb::utils::logger::StdoutLogger;
 
 const VERSION: &'static str = "0.1.0";
 const AUTHOR: &'static str = "Tibor Benke <tibor.benke@balabit.com>";
@@ -61,12 +65,20 @@ fn handle_parse(matches: &ArgMatches) {
     let output_file = matches.value_of(OUTPUT_FILE).unwrap();
 
     if let Err(e) = parse::parse(pattern_file, input_file, output_file) {
-        println!("{:?}", e);
+        error!("{:?}", e);
         std::process::exit(1);
     }
 }
 
+fn setup_stdout_logger() {
+    let _ = log::set_logger(|max_log_level| {
+        max_log_level.set(LogLevelFilter::Info);
+        Box::new(StdoutLogger)
+    });
+}
+
 fn main() {
+    setup_stdout_logger();
     let matches = build_command_line_argument_parser().get_matches();
 
     if let Some(matches) = matches.subcommand_matches(VALIDATE) {
@@ -74,6 +86,6 @@ fn main() {
     } else if let Some(matches) = matches.subcommand_matches(PARSE) {
         handle_parse(&matches);
     } else {
-        println!("{:?}", matches.usage.as_ref().unwrap());
+        error!("{:?}", matches.usage.as_ref().unwrap());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate log;
+
 mod parsers;
 mod utils;
 pub mod matcher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 extern crate log;
 
 mod parsers;
-mod utils;
+pub mod utils;
 pub mod matcher;
 pub mod grammar;
 

--- a/src/matcher/trie/node/literal.rs
+++ b/src/matcher/trie/node/literal.rs
@@ -77,11 +77,11 @@ impl LiteralNode {
                          node: self_node} = self;
 
         let common_prefix = literal.rtrunc(literal.len() - common_prefix_len);
-        println!("split(): common_prefix = {}", common_prefix);
+        trace!("split(): common_prefix = {}", common_prefix);
         let left_branch = literal.ltrunc(common_prefix_len);
         let right_branch = self_literal.ltrunc(common_prefix_len);
-        println!("split(): left_branch = {}", left_branch);
-        println!("split(): right_branch = {}", right_branch);
+        trace!("split(): left_branch = {}", left_branch);
+        trace!("split(): right_branch = {}", right_branch);
 
         let mut node_to_return = LiteralNode::from_str(common_prefix);
 

--- a/src/matcher/trie/node/parser.rs
+++ b/src/matcher/trie/node/parser.rs
@@ -34,7 +34,7 @@ impl ParserNode {
 
     pub fn parse<'a, 'b>(&'a self, text: &'b str) -> Option<Vec<(&'a str, &'b str)>> {
         if let Some(parsed_kwpair) = self.parser.parse(text) {
-            println!("parse(): parsed_kwpair = {:?}", &parsed_kwpair);
+            trace!("parse(): parsed_kwpair = {:?}", &parsed_kwpair);
             let text = text.ltrunc(parsed_kwpair.1.len());
 
             return match self.node() {

--- a/src/utils/logger.rs
+++ b/src/utils/logger.rs
@@ -1,0 +1,17 @@
+extern crate log;
+
+use log::{LogRecord, LogLevel, LogMetadata};
+
+pub struct StdoutLogger;
+
+impl log::Log for StdoutLogger {
+    fn enabled(&self, metadata: &LogMetadata) -> bool {
+        metadata.level() <= LogLevel::Info
+    }
+
+    fn log(&self, record: &LogRecord) {
+        if self.enabled(record.metadata()) {
+            println!("{} - {}", record.level(), record.args());
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,7 @@ pub use self::sortedvec::SortedVec;
 pub use self::common_prefix::CommonPrefix;
 
 mod sortedvec;
+pub mod logger;
 // it shouldn't be public, but https://github.com/rust-lang/rust/issues/16264
 pub mod common_prefix;
 


### PR DESCRIPTION
This PR removes the use of direct `println!()` calls in the library. They are replaced with macros from
the `log` facade, so any library user can override where the logs should go.

The `println!()` calls weren't removed from the tests, because they are helpful during checking failed tests.