### PR TITLE
Matcher: implement Clone trait

### DIFF
--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -9,6 +9,7 @@ use grammar::parser;
 use grammar::parser::ParseError;
 use self::trie::ParserTrie;
 
+#[derive(Clone)]
 pub struct Matcher {
     parser: ParserTrie
 }

--- a/src/matcher/trie/node/literal.rs
+++ b/src/matcher/trie/node/literal.rs
@@ -5,7 +5,7 @@ use matcher::trie::node::{Node, ParserNode};
 use matcher::trie::TrieOperations;
 use parsers::Parser;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LiteralNode {
     literal: String,
     has_value: bool,

--- a/src/matcher/trie/node/node.rs
+++ b/src/matcher/trie/node/node.rs
@@ -12,7 +12,7 @@ pub enum TokenType {
     Literal(String)
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Node {
     literal_children: SortedVec<LiteralNode>,
     parser_children: Vec<ParserNode>

--- a/src/matcher/trie/node/parser.rs
+++ b/src/matcher/trie/node/parser.rs
@@ -75,3 +75,12 @@ impl TrieOperations for ParserNode {
         self.node.as_mut().unwrap().insert_parser(parser)
     }
 }
+
+impl Clone for ParserNode {
+    fn clone(&self) -> ParserNode {
+        ParserNode{
+            parser: self.parser.boxed_clone(),
+            node: self.node.clone()
+        }
+    }
+}

--- a/src/matcher/trie/trie.rs
+++ b/src/matcher/trie/trie.rs
@@ -2,7 +2,7 @@ use matcher::trie::node::{Node, TokenType};
 use matcher::trie::node::{CompiledPattern};
 use matcher::trie::TrieOperations;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ParserTrie {
     root: Node,
 }

--- a/src/parsers/base.rs
+++ b/src/parsers/base.rs
@@ -1,4 +1,4 @@
-#[derive(Hash, Debug)]
+#[derive(Clone, Hash, Debug)]
 pub struct ParserBase {
     name: String
 }

--- a/src/parsers/greedy.rs
+++ b/src/parsers/greedy.rs
@@ -1,7 +1,7 @@
 use std::hash::{SipHasher, Hash, Hasher};
 use super::{ParserBase, Parser, ObjectSafeHash};
 
-#[derive(Debug, Hash)]
+#[derive(Clone, Debug, Hash)]
 pub struct GreedyParser {
     base: ParserBase,
     end_string: Option<String>
@@ -48,6 +48,10 @@ impl Parser for GreedyParser {
 
     fn name(&self) -> &str {
         self.base.name()
+    }
+
+    fn boxed_clone(&self) -> Box<Parser> {
+        Box::new(self.clone())
     }
 }
 

--- a/src/parsers/int.rs
+++ b/src/parsers/int.rs
@@ -2,7 +2,7 @@ use std::hash::{SipHasher, Hash, Hasher};
 
 use parsers::{Parser, ObjectSafeHash, SetParser, HasOptionalParameter, OptionalParameter};
 
-#[derive(Debug, Hash)]
+#[derive(Clone, Debug, Hash)]
 pub struct IntParser {
     delegate: SetParser
 }
@@ -33,6 +33,10 @@ impl Parser for IntParser {
 
     fn name(&self) -> &str {
         self.delegate.name()
+    }
+
+    fn boxed_clone(&self) -> Box<Parser> {
+        Box::new(self.clone())
     }
 }
 

--- a/src/parsers/length_checked.rs
+++ b/src/parsers/length_checked.rs
@@ -1,6 +1,6 @@
 use parsers::{HasOptionalParameter, OptionalParameter, ParserBase};
 
-#[derive(Hash, Debug)]
+#[derive(Clone, Hash, Debug)]
 pub struct LengthCheckedParserBase {
     base: ParserBase,
     min_length: Option<usize>,

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -18,8 +18,8 @@ pub trait ObjectSafeHash {
 pub trait Parser: Debug + ObjectSafeHash {
     fn parse<'a, 'b>(&'a self, value: &'b str) -> Option<(&'a str, &'b str)>;
     fn name(&self) -> &str;
+    fn boxed_clone(&self) -> Box<Parser>;
 }
-
 
 pub trait HasOptionalParameter {
     fn set_optional_params<'a>(&mut self, params: &Vec<OptionalParameter<'a>>) -> bool;

--- a/src/parsers/set.rs
+++ b/src/parsers/set.rs
@@ -4,7 +4,7 @@ use std::hash::{SipHasher, Hash, Hasher};
 
 use parsers::{Parser, ObjectSafeHash, LengthCheckedParserBase, HasOptionalParameter, OptionalParameter};
 
-#[derive(Debug, Hash)]
+#[derive(Clone, Debug, Hash)]
 pub struct SetParser {
     character_set: BTreeSet<u8>,
     base: LengthCheckedParserBase
@@ -65,6 +65,10 @@ impl Parser for SetParser {
 
     fn name(&self) -> &str {
         self.base.name()
+    }
+
+    fn boxed_clone(&self) -> Box<Parser> {
+        Box::new(self.clone())
     }
 }
 

--- a/src/utils/sortedvec.rs
+++ b/src/utils/sortedvec.rs
@@ -1,6 +1,6 @@
 use std::cmp::Ordering;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SortedVec<T> {
     array: Vec<T>
 }


### PR DESCRIPTION
It is needed by syslog-ng's logpipe clone() method. This way a parser can
be present in multiple logpaths.

Every other part of a Matcher needs to implement Clone, that's why the
other changes.

Note, that ParserNode manually implements the Clone trait and the Parser
trait is extended with a boxed_clone() method. The Parser trait cannot
implement Clone because it's not object safe and that's screw up
everything. The boxed_clone() method can be extracted into it's own trait
but it only makes sense to use it with parameters, like BoxedClone<Parser>.
That solution was rejected by the compiler.

Signed-off-by: Tibor Benke <ihrwein@gmail.com>