### PR TITLE
lib: export parsers module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #[macro_use]
 extern crate log;
 
-mod parsers;
+pub mod parsers;
 pub mod utils;
 pub mod matcher;
 pub mod grammar;


### PR DESCRIPTION
This export removes the compiler warnings when you run `cargo build`.

Signed-off-by: Tibor Benke <ihrwein@gmail.com>