### PR TITLE
F/matcher refact

### DIFF
--- a/src/bin/adbtool.rs
+++ b/src/bin/adbtool.rs
@@ -6,7 +6,7 @@ extern crate log;
 mod parse;
 
 use clap::{Arg, App, SubCommand, ArgMatches};
-use actiondb::Matcher;
+use actiondb::matcher::Factory;
 use log::{LogLevelFilter};
 use actiondb::utils::logger::StdoutLogger;
 
@@ -53,7 +53,7 @@ fn build_command_line_argument_parser<'a, 'b, 'c, 'd, 'e, 'f>() -> App<'a, 'b, '
 
 fn handle_validate(matches: &ArgMatches) {
     let pattern_file = matches.value_of(PATTERN_FILE).unwrap();
-    if let Err(e) = Matcher::from_file(pattern_file) {
+    if let Err(e) = Factory::from_plain_file(pattern_file) {
         println!("{:?}", e);
         std::process::exit(1);
     }

--- a/src/bin/parse.rs
+++ b/src/bin/parse.rs
@@ -1,9 +1,10 @@
 use std::fs::File;
 use std::io::{BufReader, BufRead, Error, ErrorKind, BufWriter, Write};
 use actiondb::Matcher;
+use actiondb::matcher;
 
 pub fn parse(pattern_file_path: &str, input_file_path: &str, output_file_path: &str) -> Result<(), Error> {
-    match Matcher::from_file(pattern_file_path) {
+    match matcher::Factory::from_plain_file(pattern_file_path) {
         Ok(matcher) => {
             let input_file = try!(File::open(input_file_path));
             let mut output_file= try!(File::create(output_file_path));
@@ -16,7 +17,7 @@ pub fn parse(pattern_file_path: &str, input_file_path: &str, output_file_path: &
     }
 }
 
-fn parse_file(input_file: &File, output_file: &mut File, matcher: &Matcher) {
+fn parse_file(input_file: &File, output_file: &mut File, matcher: &Box<Matcher>) {
     let reader = BufReader::new(input_file);
     let mut writer = BufWriter::new(output_file);
 

--- a/src/matcher/factory.rs
+++ b/src/matcher/factory.rs
@@ -5,28 +5,24 @@ use super::pattern::source::PatternSource;
 use super::matcher::builder;
 
 #[derive(Clone, Debug)]
-pub struct Matcher {
+pub struct Factory {
     parser: ParserTrie
 }
 
-impl Matcher {
-    pub fn from_file(pattern_file_path: &str) -> Result<Matcher, builder::BuildError> {
+impl Factory {
+    pub fn from_plain_file(pattern_file_path: &str) -> Result<Factory, builder::BuildError> {
         let file = try!(file::PlainPatternFile::open(pattern_file_path));
-        Matcher::drain_into(&mut file.into_iter())
+        Factory::drain_into(&mut file.into_iter())
     }
 
-    pub fn from_json_file(pattern_file_path: &str) -> Result<Matcher, builder::BuildError> {
+    pub fn from_json_file(pattern_file_path: &str) -> Result<Factory, builder::BuildError> {
         let file = try!(file::SerializedPatternFile::open(pattern_file_path));
-        Matcher::drain_into(&mut file.into_iter())
+        Factory::drain_into(&mut file.into_iter())
     }
 
-    pub fn drain_into(source: &mut PatternSource) -> Result<Matcher, builder::BuildError> {
+    pub fn drain_into(source: &mut PatternSource) -> Result<Factory, builder::BuildError> {
         let mut trie = ParserTrie::new();
         try!(builder::Builder::drain_into(source, &mut trie));
-        Ok(Matcher{ parser: trie })
-    }
-
-    pub fn parse<'a, 'b>(&'a self, text: &'b str) -> Option<MatchResult<'a, 'b>> {
-        self.parser.parse(text)
+        Ok(Factory{ parser: trie })
     }
 }

--- a/src/matcher/factory.rs
+++ b/src/matcher/factory.rs
@@ -1,28 +1,26 @@
 use super::trie::ParserTrie;
-use super::result::MatchResult;
 use super::pattern::file;
 use super::pattern::source::PatternSource;
 use super::matcher::builder;
+use super::matcher::Matcher;
 
 #[derive(Clone, Debug)]
-pub struct Factory {
-    parser: ParserTrie
-}
+pub struct Factory;
 
 impl Factory {
-    pub fn from_plain_file(pattern_file_path: &str) -> Result<Factory, builder::BuildError> {
+    pub fn from_plain_file(pattern_file_path: &str) -> Result<Box<Matcher>, builder::BuildError> {
         let file = try!(file::PlainPatternFile::open(pattern_file_path));
         Factory::drain_into(&mut file.into_iter())
     }
 
-    pub fn from_json_file(pattern_file_path: &str) -> Result<Factory, builder::BuildError> {
+    pub fn from_json_file(pattern_file_path: &str) -> Result<Box<Matcher>, builder::BuildError> {
         let file = try!(file::SerializedPatternFile::open(pattern_file_path));
         Factory::drain_into(&mut file.into_iter())
     }
 
-    pub fn drain_into(source: &mut PatternSource) -> Result<Factory, builder::BuildError> {
+    pub fn drain_into(source: &mut PatternSource) -> Result<Box<Matcher>, builder::BuildError> {
         let mut trie = ParserTrie::new();
         try!(builder::Builder::drain_into(source, &mut trie));
-        Ok(Factory{ parser: trie })
+        Ok(Box::new(trie))
     }
 }

--- a/src/matcher/factory.rs
+++ b/src/matcher/factory.rs
@@ -1,0 +1,32 @@
+use super::trie::ParserTrie;
+use super::result::MatchResult;
+use super::pattern::file;
+use super::pattern::source::PatternSource;
+use super::matcher::builder;
+
+#[derive(Clone, Debug)]
+pub struct Matcher {
+    parser: ParserTrie
+}
+
+impl Matcher {
+    pub fn from_file(pattern_file_path: &str) -> Result<Matcher, builder::BuildError> {
+        let file = try!(file::PlainPatternFile::open(pattern_file_path));
+        Matcher::drain_into(&mut file.into_iter())
+    }
+
+    pub fn from_json_file(pattern_file_path: &str) -> Result<Matcher, builder::BuildError> {
+        let file = try!(file::SerializedPatternFile::open(pattern_file_path));
+        Matcher::drain_into(&mut file.into_iter())
+    }
+
+    pub fn drain_into(source: &mut PatternSource) -> Result<Matcher, builder::BuildError> {
+        let mut trie = ParserTrie::new();
+        try!(builder::Builder::drain_into(source, &mut trie));
+        Ok(Matcher{ parser: trie })
+    }
+
+    pub fn parse<'a, 'b>(&'a self, text: &'b str) -> Option<MatchResult<'a, 'b>> {
+        self.parser.parse(text)
+    }
+}

--- a/src/matcher/matcher/builder/builder.rs
+++ b/src/matcher/matcher/builder/builder.rs
@@ -1,24 +1,22 @@
-use matcher::trie::ParserTrie;
 use matcher::pattern::{Pattern, PatternSource};
 use matcher::pattern::testmessage::{TestMessage, TestPairsError};
-
+use matcher::Matcher;
 use super::BuildError;
 
 pub struct Builder;
 
 impl Builder {
-    pub fn drain_into(from: &mut PatternSource, to: &mut ParserTrie) -> Result<(), BuildError>{
+    pub fn drain_into(from: &mut PatternSource, matcher: &mut Matcher) -> Result<(), BuildError>{
         for pattern in from {
             let mut pattern = try!(pattern);
-            let test_messages = Builder::extract_test_messages_from_pattern(&mut pattern);
-            to.insert(pattern);
-            try!(Builder::check_test_messages_on_trie(&to, &test_messages));
+            let test_messages = Builder::extract_test_messages(&mut pattern);
+            matcher.add_pattern(pattern);
+            try!(Builder::check_test_messages(matcher, &test_messages));
         }
-
         Ok(())
     }
 
-    fn extract_test_messages_from_pattern(pattern: &mut Pattern) -> Vec<TestMessage> {
+    fn extract_test_messages(pattern: &mut Pattern) -> Vec<TestMessage> {
         let mut messages = Vec::new();
 
         while let Some(test_message) = pattern.pop_test_message() {
@@ -27,9 +25,9 @@ impl Builder {
         messages
     }
 
-    fn check_test_messages_on_trie(trie: &ParserTrie, messages: &[TestMessage]) -> Result<(), BuildError> {
+    fn check_test_messages(matcher: &Matcher, messages: &[TestMessage]) -> Result<(), BuildError> {
         for msg in messages {
-            let result = try!(trie.parse(msg.message()).ok_or(TestPairsError::TestMessageDoesntMatch));
+            let result = try!(matcher.parse(msg.message()).ok_or(TestPairsError::TestMessageDoesntMatch));
             try!(msg.test_pairs(result.pairs()));
         }
         Ok(())

--- a/src/matcher/matcher/mod.rs
+++ b/src/matcher/matcher/mod.rs
@@ -1,33 +1,10 @@
-use super::trie::ParserTrie;
 use super::result::MatchResult;
-use super::pattern::file;
-use super::pattern::source::PatternSource;
+use super::pattern::Pattern;
+use std::fmt;
 
 pub mod builder;
 
-#[derive(Clone, Debug)]
-pub struct Matcher {
-    parser: ParserTrie
-}
-
-impl Matcher {
-    pub fn from_file(pattern_file_path: &str) -> Result<Matcher, builder::BuildError> {
-        let file = try!(file::PlainPatternFile::open(pattern_file_path));
-        Matcher::drain_into(&mut file.into_iter())
-    }
-
-    pub fn from_json_file(pattern_file_path: &str) -> Result<Matcher, builder::BuildError> {
-        let file = try!(file::SerializedPatternFile::open(pattern_file_path));
-        Matcher::drain_into(&mut file.into_iter())
-    }
-
-    pub fn drain_into(source: &mut PatternSource) -> Result<Matcher, builder::BuildError> {
-        let mut trie = ParserTrie::new();
-        try!(builder::Builder::drain_into(source, &mut trie));
-        Ok(Matcher{ parser: trie })
-    }
-
-    pub fn parse<'a, 'b>(&'a self, text: &'b str) -> Option<MatchResult<'a, 'b>> {
-        self.parser.parse(text)
-    }
+pub trait Matcher: fmt::Debug {
+    fn parse<'a, 'b>(&'a self, text: &'b str) -> Option<MatchResult<'a, 'b>>;
+    fn add_pattern(&mut self, pattern: Pattern);
 }

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -2,6 +2,7 @@ pub mod trie;
 pub mod pattern;
 pub mod result;
 pub mod matcher;
+pub mod factory;
 
 pub use self::pattern::Pattern;
 pub use self::matcher::Matcher;

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -6,3 +6,4 @@ pub mod factory;
 
 pub use self::pattern::Pattern;
 pub use self::matcher::Matcher;
+pub use self::factory::Factory;

--- a/src/matcher/trie/matcher.rs
+++ b/src/matcher/trie/matcher.rs
@@ -1,0 +1,13 @@
+use matcher::Matcher;
+use super::ParserTrie;
+use matcher::result::MatchResult;
+use matcher::pattern::Pattern;
+
+impl Matcher for ParserTrie {
+    fn parse<'a, 'b>(&'a self, text: &'b str) -> Option<MatchResult<'a, 'b>> {
+        self.parse(text)
+    }
+    fn add_pattern(&mut self, pattern: Pattern) {
+        self.insert(pattern);
+    }
+}

--- a/src/matcher/trie/mod.rs
+++ b/src/matcher/trie/mod.rs
@@ -1,5 +1,6 @@
 pub mod node;
 mod trie;
+mod matcher;
 
 use self::node::{LiteralNode, ParserNode};
 use parsers::Parser;

--- a/tests/matcher/mod.rs
+++ b/tests/matcher/mod.rs
@@ -1,19 +1,20 @@
 extern crate actiondb;
 
 use actiondb::Matcher;
+use actiondb::matcher::Factory;
 use actiondb::matcher::matcher::builder::BuildError;
 
 #[test]
 fn test_given_pattern_file_when_its_syntax_is_ok_then_matcher_can_be_built_from_it() {
     let pattern_file_path = "tests/matcher/ssh_ok.pattern";
-    let matcher = Matcher::from_file(pattern_file_path);
+    let matcher = Factory::from_plain_file(pattern_file_path);
     assert_eq!(matcher.is_ok(), true);
 }
 
 #[test]
 fn test_given_pattern_file_when_its_syntax_is_not_ok_then_matcher_cannot_be_built_from_it() {
     let pattern_file_path = "tests/matcher/ssh_wrong.pattern";
-    match Matcher::from_file(pattern_file_path) {
+    match Factory::from_plain_file(pattern_file_path) {
         Err(BuildError::FromPlain(_)) => {},
         _ => unreachable!()
     }
@@ -22,7 +23,7 @@ fn test_given_pattern_file_when_its_syntax_is_not_ok_then_matcher_cannot_be_buil
 #[test]
 fn test_given_json_file_when_its_syntax_is_ok_then_matcher_can_be_built_from_it() {
     let pattern_file_path = "tests/matcher/ssh_ok.json";
-    let matcher = Matcher::from_json_file(pattern_file_path);
+    let matcher = Factory::from_json_file(pattern_file_path);
     println!("{:?}", &matcher);
     matcher.ok().expect("Failed to create a Matched from a valid JSON pattern file");
 }
@@ -30,13 +31,13 @@ fn test_given_json_file_when_its_syntax_is_ok_then_matcher_can_be_built_from_it(
 #[test]
 fn test_given_json_file_when_its_syntax_is_not_ok_then_matcher_cannot_be_built_from_it() {
     let pattern_file_path = "tests/matcher/ssh_wrong.json";
-    let matcher = Matcher::from_json_file(pattern_file_path);
+    let matcher = Factory::from_json_file(pattern_file_path);
     matcher.err().expect("Failed to get an error when a Matcher is created from an invalid JSON file");
 }
 
 #[test]
 fn test_given_non_existing_json_file_when_it_is_loaded_then_matcher_cannot_be_created_from_it() {
     let pattern_file_path = "tests/matcher/ssh_non_existing.json";
-    let matcher = Matcher::from_json_file(pattern_file_path);
+    let matcher = Factory::from_json_file(pattern_file_path);
     matcher.err().expect("Failed to get an error when a Matcher is created from a non-existing JSON file");
 }


### PR DESCRIPTION
This PR generalizes the parsing and parser building logic in the following manner:
* a `Matcher` trait is created which has a `parse()` and `add_pattern()` method
* `ParserTrie` implement the `Matcher` trait
* the previous Matcher struct is renamed to matcher::Factory and can be used to create `Matcher` instances
* adbtool and the tests are updated to apply these changes