### PR TITLE
grammar: allow dots (.) in parser names

### DIFF
--- a/src/grammar/pattern.rustpeg
+++ b/src/grammar/pattern.rustpeg
@@ -99,7 +99,7 @@ parser_name -> &'input str
   = ":" name:identifier { name }
 
 identifier -> &'input str
-  = [a-zA-Z_]([a-z-A-Z0-9_]![-])* { match_str }
+  = [a-zA-Z_.]([a-z-A-Z0-9_.]![-])* { match_str }
 
 string -> &'input str
   = '"' s:all_chars_until_quotation_mark '"' { s }

--- a/src/grammar/pattern_parser.rs
+++ b/src/grammar/pattern_parser.rs
@@ -869,10 +869,11 @@ fn parse_identifier<'input>(input: &'input str, state: &mut ParseState,
                 if input.len() > pos {
                     let (ch, next) = char_range_at(input, pos);
                     match ch {
-                        'a' ...'z' | 'A' ...'Z' | '_' => Matched(next, ()),
-                        _ => state.mark_failure(pos, "[a-zA-Z_]"),
+                        'a' ...'z' | 'A' ...'Z' | '_' | '.' =>
+                        Matched(next, ()),
+                        _ => state.mark_failure(pos, "[a-zA-Z_.]"),
                     }
-                } else { state.mark_failure(pos, "[a-zA-Z_]") };
+                } else { state.mark_failure(pos, "[a-zA-Z_.]") };
             match seq_res {
                 Matched(pos, _) => {
                     {
@@ -891,15 +892,15 @@ fn parse_identifier<'input>(input: &'input str, state: &mut ParseState,
                                                     match ch {
                                                         'a' ...'z' | '-' | 'A'
                                                         ...'Z' | '0' ...'9' |
-                                                        '_' =>
+                                                        '_' | '.' =>
                                                         Matched(next, ()),
                                                         _ =>
                                                         state.mark_failure(pos,
-                                                                           "[a-z-A-Z0-9_]"),
+                                                                           "[a-z-A-Z0-9_.]"),
                                                     }
                                                 } else {
                                                     state.mark_failure(pos,
-                                                                       "[a-z-A-Z0-9_]")
+                                                                       "[a-z-A-Z0-9_.]")
                                                 };
                                             match seq_res {
                                                 Matched(pos, _) => {

--- a/src/grammar/test.rs
+++ b/src/grammar/test.rs
@@ -157,3 +157,10 @@ fn test_given_greedy_parser_when_there_is_no_literal_after_it_then_we_take_all_t
         unreachable!();
     }
 }
+
+#[test]
+fn test_given_parser_when_there_is_a_dot_in_its_name_then_it_is_ok() {
+    let pattern_as_string = "bar %{GREEDY:.some.dotted_notation}";
+    let vec: Vec<TokenType<>> = pattern_parser::pattern(pattern_as_string).ok().unwrap();
+    assert_parser_name_equals(vec.get(1), ".some.dotted_notation");
+}


### PR DESCRIPTION
Fixes #28

Signed-off-by: Tibor Benke <ihrwein@gmail.com>