### PR TITLE
Cargo: use concrete dependency version instead of * ones

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "adbtool"
 path = "src/bin/adbtool.rs"
 
 [dependencies]
-clap = "*"
-log = "*"
-uuid = "*"
+clap = "1.0"
+log = "0.3"
+uuid = "0.1"
 serde = "0.4"


### PR DESCRIPTION
Signed-off-by: Tibor Benke <tibor.benke@balabit.com>