### PR TITLE
F/matcher factory

### DIFF
--- a/src/bin/parse.rs
+++ b/src/bin/parse.rs
@@ -17,7 +17,7 @@ pub fn parse(pattern_file_path: &str, input_file_path: &str, output_file_path: &
     }
 }
 
-fn parse_file(input_file: &File, output_file: &mut File, matcher: &Box<Matcher>) {
+fn parse_file(input_file: &File, output_file: &mut File, matcher: &Matcher) {
     let reader = BufReader::new(input_file);
     let mut writer = BufWriter::new(output_file);
 

--- a/src/matcher/factory.rs
+++ b/src/matcher/factory.rs
@@ -39,3 +39,8 @@ impl Factory {
         Box::new(trie)
     }
 }
+
+pub trait MatcherFactory {
+    type Matcher: Matcher;
+    fn new_matcher() -> Self::Matcher;
+}

--- a/src/matcher/factory.rs
+++ b/src/matcher/factory.rs
@@ -2,6 +2,7 @@ use super::trie::ParserTrie;
 use super::pattern::file;
 use super::matcher::builder;
 use super::matcher::Matcher;
+use matcher::trie::factory::TrieMatcherFactory;
 
 use std::path;
 use std::ffi;
@@ -10,33 +11,43 @@ use std::ffi;
 pub struct Factory;
 
 impl Factory {
-    pub fn from_json_file(pattern_file_path: &str) -> Result<Box<Matcher>, builder::BuildError> {
-        let mut matcher = Factory::new();
+    pub fn from_json_file(pattern_file_path: &str) -> Result<ParserTrie, builder::BuildError> {
+        GenericFactory::from_json_file::<TrieMatcherFactory>(pattern_file_path)
+    }
+
+    pub fn from_file(pattern_file_path: &str) -> Result<ParserTrie, builder::BuildError> {
+        GenericFactory::from_file::<TrieMatcherFactory>(pattern_file_path)
+    }
+}
+
+pub struct GenericFactory;
+
+impl GenericFactory {
+    pub fn from_json_file<F>(pattern_file_path: &str) -> Result<F::Matcher, builder::BuildError>
+        where F: MatcherFactory {
+        let mut matcher = F::new_matcher();
         let file = try!(file::SerializedPatternFile::open(pattern_file_path));
-        try!(builder::Builder::drain_into(&mut file.into_iter(), &mut *matcher));
+        try!(builder::Builder::drain_into(&mut file.into_iter(), &mut matcher));
         Ok(matcher)
     }
 
-    pub fn from_file(pattern_file_path: &str) -> Result<Box<Matcher>, builder::BuildError> {
+    pub fn from_file<F>(pattern_file_path: &str) -> Result<F::Matcher, builder::BuildError>
+        where F: MatcherFactory {
         let path = path::Path::new(pattern_file_path);
         match path.extension() {
             Some(extension) => {
-                Factory::from_file_based_on_extension(extension, pattern_file_path)
+                GenericFactory::from_file_based_on_extension::<F>(extension, pattern_file_path)
             },
             None => Err(builder::BuildError::UnsupportedFileExtension)
         }
     }
 
-    fn from_file_based_on_extension(extension: &ffi::OsStr, pattern_file_path: &str) -> Result<Box<Matcher>, builder::BuildError> {
+    fn from_file_based_on_extension<F>(extension: &ffi::OsStr, pattern_file_path: &str) -> Result<F::Matcher, builder::BuildError>
+        where F: MatcherFactory {
         match try!(extension.to_str().ok_or(builder::BuildError::NotUtf8FileName)) {
-            "json" => Factory::from_json_file(pattern_file_path),
+            "json" => GenericFactory::from_json_file::<F>(pattern_file_path),
             _ => Err(builder::BuildError::UnsupportedFileExtension)
         }
-    }
-
-    pub fn new() -> Box<Matcher> {
-        let trie = ParserTrie::new();
-        Box::new(trie)
     }
 }
 

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -8,3 +8,4 @@ pub mod compiled_pattern;
 pub use self::pattern::Pattern;
 pub use self::matcher::Matcher;
 pub use self::factory::Factory;
+pub use self::factory::MatcherFactory;

--- a/src/matcher/mod.rs
+++ b/src/matcher/mod.rs
@@ -8,4 +8,5 @@ pub mod compiled_pattern;
 pub use self::pattern::Pattern;
 pub use self::matcher::Matcher;
 pub use self::factory::Factory;
+pub use self::factory::GenericFactory;
 pub use self::factory::MatcherFactory;

--- a/src/matcher/trie/factory.rs
+++ b/src/matcher/trie/factory.rs
@@ -1,0 +1,12 @@
+use matcher::factory::MatcherFactory;
+use matcher::trie::ParserTrie;
+
+pub struct TrieMatcherFactory;
+
+impl MatcherFactory for TrieMatcherFactory {
+    type Matcher = ParserTrie;
+
+    fn new_matcher() -> Self::Matcher {
+        ParserTrie::new()
+    }
+}

--- a/src/matcher/trie/mod.rs
+++ b/src/matcher/trie/mod.rs
@@ -1,5 +1,6 @@
 pub mod node;
 pub mod parser_factory;
+pub mod factory;
 mod trie;
 mod matcher;
 


### PR DESCRIPTION
Make Matcher creation generic :smile: 

Other Matcher implementations can be constructed with the same `GenericFactory` struct.