### PR TITLE
F/pattern refact

### DIFF
--- a/src/matcher/pattern/pattern.rs
+++ b/src/matcher/pattern/pattern.rs
@@ -72,12 +72,12 @@ impl Pattern {
         self.pattern = pattern;
     }
 
-    pub fn pop_first_token(&mut self) -> TokenType {
-        self.pattern.remove(0)
-    }
-
-    pub fn has_more_tokens(&self) -> bool {
-        !self.pattern.is_empty()
+    pub fn pop_first_token(&mut self) -> Option<TokenType> {
+        if self.pattern.is_empty() {
+            None
+        } else {
+            Some(self.pattern.remove(0))
+        }
     }
 
     pub fn pop_test_message(&mut self) -> Option<TestMessage> {

--- a/src/matcher/trie/node/node.rs
+++ b/src/matcher/trie/node/node.rs
@@ -1,5 +1,6 @@
 use parsers::{Parser, ParseResult};
 use utils::{SortedVec, CommonPrefix};
+use matcher::pattern::Pattern;
 use matcher::trie::node::LiteralNode;
 use matcher::trie::node::ParserNode;
 use matcher::trie::{HasPattern, TrieOperations};
@@ -209,6 +210,11 @@ impl Node {
         let (node, pos) = branching_node.node_mut().unwrap().lookup_literal_mut(literal).ok().unwrap();
         node.literal_children.get_mut(pos).unwrap()
     }
+}
+
+impl HasPattern for Node {
+    fn set_pattern(&mut self, _: Pattern) {}
+    fn pattern(&self) -> Option<&Pattern> {None}
 }
 
 impl TrieOperations for Node {


### PR DESCRIPTION
Refactor the `pop_first_token()` method. It was used by the insertion logic in ParserTrie which was simplified as well.