### PR TITLE
derive Clone trait for MatcherSuite implementations

### DIFF
--- a/src/matcher/suffix_array/mod.rs
+++ b/src/matcher/suffix_array/mod.rs
@@ -20,6 +20,7 @@ impl MatcherFactory for SuffixArrayMatcherFactory {
     }
 }
 
+#[derive(Clone)]
 pub struct SuffixArrayMatcherSuite;
 
 impl MatcherSuite for SuffixArrayMatcherSuite {

--- a/src/matcher/trie/suite.rs
+++ b/src/matcher/trie/suite.rs
@@ -3,6 +3,7 @@ use matcher::trie::SuffixTree;
 use matcher::trie::parser_factory::TrieParserFactory;
 use matcher::trie::factory::TrieMatcherFactory;
 
+#[derive(Clone)]
 pub struct TrieMatcherSuite;
 
 impl MatcherSuite for TrieMatcherSuite {


### PR DESCRIPTION
I didn't touch the `MatcherSuite` trait, because not all matcher suites should be cloneable.