### PR TITLE
Fix UTF-8 handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
     - rust: nightly
       env: TRAVIS_CARGO_NIGHTLY_FEATURE=nightly
     - rust: beta
-    - rust: stable
 
 # load travis-cargo
 before_script:

--- a/src/grammar/test.rs
+++ b/src/grammar/test.rs
@@ -1,5 +1,5 @@
 use matcher::compiled_pattern::TokenType;
-use parsers::{SetParser, Parser, ObjectSafeHash, IntParser, GreedyParser, HasLengthConstraint};
+use parsers::{SetParser, Parser, IntParser, GreedyParser, HasLengthConstraint};
 
 fn assert_parser_name_equals(item: Option<&TokenType>, expected_name: Option<&str>) {
     if let Some(&TokenType::Parser(ref parser)) = item {

--- a/src/matcher/pattern_source/mod.rs
+++ b/src/matcher/pattern_source/mod.rs
@@ -65,7 +65,7 @@ pub trait FromPatternSource {
                           expected_uuid: &Uuid)
                           -> Result<(), testmessage::Error> {
         if result.pattern().uuid() == expected_uuid {
-            message.test_result(&result)
+            message.test_result(result)
         } else {
             Err(testmessage::Error::matched_to_other_pattern(expected_uuid,
                 result.pattern().uuid(),

--- a/src/matcher/suffix_array/test.rs
+++ b/src/matcher/suffix_array/test.rs
@@ -146,3 +146,18 @@ fn test_given_suffix_array_when_literals_are_inserted_then_it_can_find_the_strin
 
     assert_eq!("app", root.longest_common_prefix("app42").unwrap().literal());
 }
+
+#[test]
+fn test_given_parser_when_it_receives_utf_8_strings_then_it_does_not_panic() {
+    let pattern = "%{GREEDY}¡%{GREEDY}";
+    let compiled_pattern = ::grammar::parser::pattern(pattern)
+                  .expect("Failed to compile pattern when it includes UTF-8 multibyte characters");
+
+    let mut pattern = Pattern::with_random_uuid();
+    pattern.set_pattern(compiled_pattern);
+
+    let mut root = SuffixTable::new();
+    root.insert(pattern);
+
+    assert_eq!(true, root.parse("micek ¡micek").is_some());
+}

--- a/src/matcher/trie/node/mod.rs
+++ b/src/matcher/trie/node/mod.rs
@@ -8,7 +8,7 @@ mod literal;
 mod parser;
 pub mod interface;
 
-use self::interface::{Entry, LiteralEntry, ParserEntry};
+use self::interface::Entry;
 
 pub use self::literal::LiteralNode;
 pub use self::parser::ParserNode;
@@ -225,7 +225,7 @@ impl SuffixTree {
                                                      .get(pos)
                                                      .unwrap()
                                                      .literal()
-                                                     .has_common_prefix(&tail) {
+                                                     .has_common_prefix(tail) {
                     trace!("insert_literal_tail(): common_prefix_len = {}",
                            common_prefix_len);
                     let hit = self.literal_children
@@ -320,7 +320,7 @@ impl self::interface::SuffixTree for SuffixTree {
 #[cfg(test)]
 mod test {
     use matcher::trie::node::SuffixTree;
-    use parsers::{Parser, SetParser, IntParser, GreedyParser};
+    use parsers::{SetParser, IntParser, GreedyParser};
     use matcher::compiled_pattern::CompiledPatternBuilder;
     use matcher::pattern::Pattern;
     use matcher::trie::node::interface::SuffixTree as STree;

--- a/src/parsers/greedy.rs
+++ b/src/parsers/greedy.rs
@@ -51,14 +51,10 @@ impl ObjectSafeHash for GreedyParser {
 
 impl Parser for GreedyParser {
     fn parse<'a, 'b>(&'a self, value: &'b str) -> Option<ParseResult<'a, 'b>> {
-        if self.end_string.is_none() {
-            return Some(ParseResult::new(self, &value[..]));
-        }
-
-        if let Some(pos) = value.find(&self.end_string.as_ref().unwrap()[..]) {
-            Some(ParseResult::new(self, &value[..pos]))
+        if let Some(end_string) = self.end_string.as_ref() {
+            value.find(end_string).map(|pos| ParseResult::new(self, &value[..pos]))
         } else {
-            None
+            Some(ParseResult::new(self, &value[..]))
         }
     }
 

--- a/src/utils/common_prefix.rs
+++ b/src/utils/common_prefix.rs
@@ -73,4 +73,9 @@ mod test {
     fn test_given_a_string_with_multibyte_utf8_character_when_we_count_their_common_prefix_len_we_dont_split_the_multibyte_character() {
         assert_eq!("¡alpha".common_prefix_len("¡beta"), 2);
     }
+
+    #[test]
+    fn test_given_a_string_with_multibyte_utf8_character_when_there_is_an_other_multibyte_character_with_the_same_first_byte_then_we_dont_split_them() {
+        assert_eq!("\u{00AE}alpha".common_prefix_len("\u{00BE}beta"), 0);
+    }
 }

--- a/src/utils/common_prefix.rs
+++ b/src/utils/common_prefix.rs
@@ -68,4 +68,9 @@ mod test {
         assert_eq!("alpha".rtrunc(0), "alpha");
         assert_eq!("alpha".rtrunc(2), "alp");
     }
+
+    #[test]
+    fn test_given_a_string_with_multibyte_utf8_character_when_we_count_their_common_prefix_len_we_dont_split_the_multibyte_character() {
+        assert_eq!("¡alpha".common_prefix_len("¡beta"), 2);
+    }
 }

--- a/src/utils/common_prefix.rs
+++ b/src/utils/common_prefix.rs
@@ -19,8 +19,8 @@ pub trait CommonPrefix {
 impl CommonPrefix for str {
     fn common_prefix_len(&self, other: &Self) -> usize {
         let min_len = cmp::min(self.len(), other.len());
-        let mut a_i = self.chars();
-        let mut b_i = other.chars();
+        let mut a_i = self.as_bytes().iter();
+        let mut b_i = other.as_bytes().iter();
 
         for i in 0..min_len {
             let x = a_i.next();

--- a/src/utils/common_prefix.rs
+++ b/src/utils/common_prefix.rs
@@ -21,13 +21,18 @@ impl CommonPrefix for str {
         let min_len = cmp::min(self.len(), other.len());
         let mut a_i = self.as_bytes().iter();
         let mut b_i = other.as_bytes().iter();
+        let mut last_valid_character_boundary = 0;
 
         for i in 0..min_len {
             let x = a_i.next();
             let y = b_i.next();
 
+            if self.is_char_boundary(i) {
+                last_valid_character_boundary = i;
+            }
+
             if x != y {
-                return i;
+                return last_valid_character_boundary;
             }
         }
         min_len


### PR DESCRIPTION
UTF-8 wasn't handled well: there were cases, when multibyte characters were splitted resulting a run time panic.

This PR intends to fix this behavior.