### PR TITLE
Re-enable builds on stable Rust

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
     - rust: nightly
       env: TRAVIS_CARGO_NIGHTLY_FEATURE=nightly
     - rust: beta
+    - rust: stable
 
 # load travis-cargo
 before_script:


### PR DESCRIPTION
We use a method from Rust 1.9: is_char_boundary(): [1]
It's in the current stable release, so we can re-enable it in Travis.

[1] http://doc.rust-lang.org/stable/std/primitive.str.html#method.is_char_boundary

Signed-off-by: Tibor Benke tibor.benke@balabit.com
